### PR TITLE
Add Filtering to Movies Service

### DIFF
--- a/src/MovieService.js
+++ b/src/MovieService.js
@@ -4,6 +4,7 @@ const mongoose = require('mongoose');
 const morgan = require('morgan');
 
 const Movie = require('./models/Movie');
+const helper = require('./helper')
 
 /**
  * A simple service for interacting a database of movies.
@@ -57,8 +58,9 @@ class MovieService {
      * @param {http.ServerResponse} res - The outgoing HTTP response.
      */
     async getAllMovies(req, res) {
+        const query = req.query
         try {
-            const movies = await Movie.find();
+            const movies = await Movie.find(helper.buildMongoQuery(query));
             res.send(movies);
         } catch (error) {
             res.status(500).send({message: error.message });

--- a/src/helper.js
+++ b/src/helper.js
@@ -1,0 +1,35 @@
+'use strict'
+
+const buildMongoQuery = (params) => {
+    const mongoQuery = {}
+    Object.keys(params).forEach(key => {
+        const value = params[key]
+        switch(key) {
+            case 'release_date':
+                const dateQuery = {}
+                if (value.lte) {
+                  dateQuery.$lte = new Date(value.lte)
+                }
+                if (value.gte) {
+                    dateQuery.$gte = new Date(value.gte)
+                }
+                mongoQuery.release_date = dateQuery
+                break
+            case 'director':
+            case 'genres':
+                mongoQuery[key] = {
+                    $in: Array.isArray(value) ? value : [value]
+                }
+                break
+            default:
+                throw new Error(
+                    `Unknown query param ${key}. Valid query params are release_date[lte], release_date[gte], director, and genres.`
+                )
+        }
+    })
+    return mongoQuery
+}
+
+module.exports = {
+    buildMongoQuery,
+}


### PR DESCRIPTION
# Description
Extends the `GET /movies` route to allow filtering of movies on `release_date`, `director`, and `genres`
This is done by passing query parameters in the request.
The accepted query parameters are
- `release_date[lte]` - date for movies which were released before the date passed formatted at` YYYY-MM-DD`
- `release_date[gte]` - date for movies which were released afterthe date passed formatted at` YYYY-MM-DD`
- `directors` - movies which were directed by the directors specified
    - can be passed multiple times
- `genres` - movies which are of the genres specified
    - can be passed multiple times

ex: `http://localhost:5000/movies?release_date[gte]=2010-1-1&release_date[lte]=2011-1-1&director=Christopher%20Nolan&genres=Action&genres=Thriller&director=Susanna%20White`